### PR TITLE
fix "the parent of layer cannot be itself nor one of its children"

### DIFF
--- a/src/libs/DuAECoreLib.jsxinc
+++ b/src/libs/DuAECoreLib.jsxinc
@@ -2186,7 +2186,7 @@ DuAEF.DuAE.Layer.parent = function(layers, parent, unparentedOnly)
 			layer.locked = false;
 			if ((layer.parent == null && unparentedOnly) || !unparentedOnly)
 			{
-				if (layer.parent != parent) layer.parent = parent;
+				if (layer.parent != parent && layer != layers[layers.length-1]) layer.parent = parent;
 			}
 			layer.locked = locked;
 		});


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2059694/59046576-d6c16480-88b4-11e9-8997-67aa54ef8688.png)

1. select 2 layers
2. click auto parent

then duik will prompt this error in dev mode, 16.10-RC4
this PR fix this error